### PR TITLE
Ability to update GroupID on user.set

### DIFF
--- a/basic_test.go
+++ b/basic_test.go
@@ -118,16 +118,22 @@ func TestGetHandler(t *testing.T) {
 			db.First(&e)
 			id := fmt.Sprint(e.ID)
 			Convey("Then we should receive an updated entity", func() {
-				msg, err := n.Request("user.set", []byte(`{"id": `+id+`, "username":"fred"}`), time.Second)
+				msg, err := n.Request("user.set", []byte(`{"id": `+id+`, "username":"fred", "password":"supu"}`), time.Second)
 				output := Entity{}
 				output.LoadFromInput(msg.Data)
 				So(output.ID, ShouldNotEqual, nil)
 				So(output.Username, ShouldEqual, "fred")
+				pwd := output.Password
 				So(err, ShouldEqual, nil)
 
 				stored := Entity{}
 				db.First(&stored, output.ID)
 				So(stored.Username, ShouldEqual, "fred")
+				So(stored.Password, ShouldEqual, pwd)
+
+				n.Request("user.set", []byte(`{"id": `+id+`, "password":""}`), time.Second)
+				db.First(&stored, output.ID)
+				So(stored.Password, ShouldEqual, pwd)
 			})
 		})
 	})

--- a/entity.go
+++ b/entity.go
@@ -123,15 +123,17 @@ func (e *Entity) LoadFromInputOrFail(msg *nats.Msg, h *natsdb.Handler) bool {
 
 // Update : It will update the current entity with the input []byte
 func (e *Entity) Update(body []byte) error {
-	e.MapInput(body)
-	stored := Entity{}
-	db.First(&stored, e.ID)
-	stored.GroupID = e.GroupID
-	stored.Username = e.Username
-	if e.Password != "" {
-		stored.Password = e.Password
+	input := Entity{}
+	json.Unmarshal(body, &input)
+	e.GroupID = input.GroupID
+	e.Username = input.Username
+
+	if input.Password != "" {
+		e.Password = input.Password
+		e.Save()
+	} else {
+		db.Save(e)
 	}
-	stored.Save()
 	return nil
 }
 
@@ -150,14 +152,16 @@ func (e *Entity) Save() error {
 		return fmt.Errorf(`{"error": "%s"}`, err.Error())
 	}
 
-	hash, err := scrypt.Key([]byte(e.Password), salt, 16384, 8, 1, HashSize)
-	if err != nil {
-		return fmt.Errorf(`{"error": "%s"}`, err.Error())
-	}
+	if e.Password != "" {
+		hash, err := scrypt.Key([]byte(e.Password), salt, 16384, 8, 1, HashSize)
+		if err != nil {
+			return fmt.Errorf(`{"error": "%s"}`, err.Error())
+		}
 
-	// Create a base64 string of the binary salt and hash for storage
-	e.Salt = base64.StdEncoding.EncodeToString(salt)
-	e.Password = base64.StdEncoding.EncodeToString(hash)
+		// Create a base64 string of the binary salt and hash for storage
+		e.Salt = base64.StdEncoding.EncodeToString(salt)
+		e.Password = base64.StdEncoding.EncodeToString(hash)
+	}
 
 	db.Save(&e)
 

--- a/entity.go
+++ b/entity.go
@@ -126,8 +126,11 @@ func (e *Entity) Update(body []byte) error {
 	e.MapInput(body)
 	stored := Entity{}
 	db.First(&stored, e.ID)
+	stored.GroupID = e.GroupID
 	stored.Username = e.Username
-	stored.Password = e.Password
+	if e.Password != "" {
+		stored.Password = e.Password
+	}
 	stored.Save()
 	return nil
 }


### PR DESCRIPTION
In case you provide a group_id on a user.set message you'll be able to update the group_id of the specified user

Example:

```
nats-request user.set '{"id":1, "group_id":2}'
```
